### PR TITLE
Issue #26390286: Reconfigure data flow throughout app.

### DIFF
--- a/app/components/_componentLibrary.js
+++ b/app/components/_componentLibrary.js
@@ -13,7 +13,6 @@ const componentLibrary = () => {
       <CTA secondary href='#' text='Click Me!' />
       {/* Gradient */}
       <CTA tertiary href='#' text='Click Me!' />
-      <SearchBar />
       <Share />
     </>
   );

--- a/app/components/card.js
+++ b/app/components/card.js
@@ -9,7 +9,7 @@ const Article = styled.article`
 const card = ({ answer, term, formattedText, resource, page }) => {
   let title;
 
-  // Process glossay term name for id or href.
+  // Process glossary term name for id or href.
   const cleanTerm = name => {
     return name.toLowerCase().replace(/ /g, '_');
   };

--- a/app/components/cardList.js
+++ b/app/components/cardList.js
@@ -1,21 +1,9 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React from 'react';
 import Card from './card';
-import { getRecordsList } from '../services/airtable-service';
 
 const cardList = (props) => {
-  const [glossary, setGlossary] = useState([]);
-  const [resources, setResources] = useState([]);
-  useEffect(() => {
-    if (props.page === 'Glossary') {
-      getRecordsList('glossary').then((recordList) => {
-        setGlossary(recordList);
-      });
-    } else if (props.page === 'Resources') {
-      getRecordsList('resources').then((recordList) => {
-        setResources(recordList);
-      });
-    }
-  }, []);
+  const glossary = props.glossary;
+  const resources = props.resources;
 
   return (
     <>

--- a/app/components/option.js
+++ b/app/components/option.js
@@ -1,50 +1,42 @@
 import React, { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
 import { getSingleRecord } from '../services/airtable-service';
 import { useLocation, useHistory } from 'react-router-dom';
 
 const option = ({ option }) => {
-  const [value, setValue] = useState('');
-  const [displayText, setDisplayText] = useState('');
-  const [nextQuestion, setNextQuestion] = useState('');
-  const [answer, setAnswer] = useState('');
   const location = useLocation();
   const history = useHistory();
+  const { value, display_text, next_question, answer } = option
+  const displayText = display_text;
+  const nextQuestion = next_question;
 
-  useEffect(() => {
-    getSingleRecord('options', option).then((record) => {
-      const { value, display_text, next_question, answer } = record.fields;
-      setValue(value);
-      setDisplayText(display_text);
-      setAnswer(answer);
-      setNextQuestion(next_question);
-    });
-  }, [option]);
-
-  const handleClick = e => {
+  const handleClick = (e) => {
     const nextPage = e.target.dataset.nextPage;
     const answer = e.target.dataset.answer;
     Object.assign(location, {
       state: { activeId: nextPage || answer },
-      pathname: answer ? `/quiz/${answer}` : location.pathname
-    })
+      pathname: answer ? `/quiz/${answer}` : location.pathname,
+    });
     history.push(location);
-  }
+  };
 
   return (
-    <div htmlFor={value} className="shadow card">
-      {displayText}
-      <input
-        type="radio"
-        id={`option-${value}`}
-        value={value}
-        name={value}
-        aria-checked
-        data-next-page={nextQuestion}
-        data-answer={answer}
-        onClick={handleClick}
-      />
-    </div>
+    <>
+      {displayText && value && (
+        <div htmlFor={value} className="shadow card">
+          {displayText}
+          <input
+            type="radio"
+            id={`option-${value}`}
+            value={value}
+            name={value}
+            aria-checked
+            data-next-page={nextQuestion}
+            data-answer={answer}
+            onClick={handleClick}
+          />
+        </div>
+      )}
+    </>
   );
 };
 

--- a/app/components/optionList.js
+++ b/app/components/optionList.js
@@ -13,7 +13,7 @@ const optionList = ({ options }) => {
   return (
     <>
       <Legend>Select Your Best Response</Legend>
-      {options &&
+      {options?.length > 0 &&
         options.map((option, index) => {
           return <Option option={option} key={index} />;
         })

--- a/app/components/searchBar.js
+++ b/app/components/searchBar.js
@@ -1,12 +1,12 @@
-import React from 'react'
+import React, { useContext } from 'react';
+import { ArchiveContext } from '../context/archiveContext';
 
-const searchBar = () => {
-  return (
-    <input
-      type='search'
-      placeholder='search'>
-    </input>
+const searchBar = (props) => {
+  const { glossary, resources, searchResults, setSearchResults } = useContext(
+    ArchiveContext
   );
-}
 
-export default searchBar
+  return <input type="search" placeholder="search"></input>;
+};
+
+export default searchBar;

--- a/app/components/titleArea.js
+++ b/app/components/titleArea.js
@@ -1,8 +1,7 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import SearchBar from './searchBar';
 import Share from './share';
 import CTA from './cta';
-import Tooltip from './tooltip';
 import styled from 'styled-components';
 
 const TitleArea = styled.div`
@@ -15,13 +14,12 @@ const titleArea = (props) => {
   return (
     <>
       <TitleArea>
-        <h1 className='sr-only'>Quiz</h1>
+        <h1 className="sr-only">Quiz</h1>
         <h2>{props.title}</h2>
-        {props.tooltip && <Tooltip text={props.tooltip} />}
         <p>{props.description}</p>
         {props.topic === 'archive' && <SearchBar />}
         {props.topic === 'answer' && (
-          <CTA tertiary text='Retake Quiz' href='/quiz' size='24px' />
+          <CTA tertiary text="Retake Quiz" href="/quiz" size="24px" />
         )}
         {props.topic === 'answer' && <Share />}
       </TitleArea>

--- a/app/context/archiveContext.js
+++ b/app/context/archiveContext.js
@@ -1,0 +1,13 @@
+import React, { useState, createContext } from 'react';
+export const ArchiveContext = createContext();
+
+export const ArchiveProvider = props => {
+  const [searchResults, setSearchResults] = useState([]);
+  const { glossary, resources } = props
+
+  return (
+    <ArchiveContext.Provider value={{ searchResults, setSearchResults, glossary, resources }}>
+      {props.children}
+    </ArchiveContext.Provider>
+  )
+}


### PR DESCRIPTION
This PR reconfigures data flow in the app in two ways:
1. A single request is made to Airtable in `App.js`, which then allows passing of an `appData` prop to children.
1. ArchiveContext has been set up to facilitate sharing information between the search bar and card list. I haven't done anything more than set up context and add the variables to `searchBar.js`.

To test, simply move through the app and verify routes/quiz work as expected. I think the only answer that has related resources right now is accessible via `Demographic Information` > `Yes`. There's a lot of logic happening in `Split.js`, but perhaps we can break that out if needed as we continue.