### PR TITLE
Issue #27070085: Adjust labs logo link so it points to /labs

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -35,12 +35,14 @@ const Footer = props => {
     >
       <FooterContainer isSplitScreen={props.split}>
         <LogoLink
-          href="https://savaslabs.com"
+          href="https://savaslabs.com/labs"
           target="_blank"
           rel="noopener noreferrer"
           isSplitScreen={props.split}
         >
-          <span className="sr-only">Open Savas Labs website in new window.</span>
+          <span className="sr-only">
+            Open the Labs page of the Savas Labs website in new window.
+          </span>
           <LabsLogoMobile />
           <LabsLogo />
         </LogoLink>
@@ -126,7 +128,9 @@ const FooterWrapper = styled.footer`
       margin-top: -105px;
     `}
 
-    ${props => props.menuEmbed && `
+    ${props =>
+      props.menuEmbed &&
+      `
       padding: 0;
       height: 0;
       width: 0;


### PR DESCRIPTION
Hi @alexmanzo , this PR updates the labs logo link href as described [in Slack](https://savaslabs.slack.com/archives/C010CG206J1/p1598644545015100). 

Also, just wanted to flag that `master` is a couple of commits ahead of `develop`.